### PR TITLE
Correction error "condition has length > 1" from 'if' function

### DIFF
--- a/R/WFO.match.R
+++ b/R/WFO.match.R
@@ -58,7 +58,7 @@ WFO.match <- function(
             WFO.names <- c(WFO.names, "New.accepted", "Old.status", "Old.ID", "Old.name")
         }
     }
-    for (i in 1:length(WFO.names)) {
+    for (i in seq_along(WFO.names)) {
         if (WFO.names[i] %in% names(spec.data)) {
             message(paste("Original data set variable '", WFO.names[i], "' replaced by variable '", WFO.names[i], ".ORIG'", sep=""))
             names(spec.data)[names(spec.data) == WFO.names[i]] <- paste(WFO.names[i], ".ORIG", sep="")
@@ -95,7 +95,7 @@ WFO.match <- function(
                 spec.name.ORIG <- paste(spec.name, ".ORIG", sep="")
                 spec.data[, spec.name.ORIG] <- spec.data[, spec.name]
             }
-            for (i in 1:length(sub.pattern)) {
+            for (i in seq_along(sub.pattern)) {
                 spec.data[, spec.name] <- gsub(pattern=sub.pattern[i], replacement="", x=spec.data[, spec.name])
             }
         }
@@ -253,7 +253,7 @@ WFO.match <- function(
 
                     if (spec.data[i, "Fuzzy.two"] == TRUE && spec.data[i, "Fuzzy.one"] == FALSE) {
                         specFuzzy.2 <- NULL
-                        for (j in 1:length(specFuzzy)) {
+                        for (j in seq_along(specFuzzy)) {
                             species.string3 <- unlist(strsplit(specFuzzy[j], split= " "))
                             if (length(species.string3) < 3) {specFuzzy.2 <- c(specFuzzy.2, specFuzzy[j])}
                         }
@@ -265,7 +265,7 @@ WFO.match <- function(
 
                     if (spec.data[i, "Fuzzy.one"] == TRUE) {
                         specFuzzy.2 <- NULL
-                        for (j in 1:length(specFuzzy)) {
+                        for (j in seq_along(specFuzzy)) {
                             species.string3 <- unlist(strsplit(specFuzzy[j], split= " "))
                             if (length(species.string3) < 2) {specFuzzy.2 <- c(specFuzzy.2, specFuzzy[j])}
                         }
@@ -301,7 +301,7 @@ WFO.match <- function(
                         specFuzzy <- specFuzzy[found.diff == min(found.diff)]
                         if (verbose == TRUE) {message(paste("Shortest fuzzy matches for ", spec.data[i, spec.name], "were: ", paste(specFuzzy, collapse=", ")))}
                     }
-                    for (j in 1:length(specFuzzy)) {
+                    for (j in seq_along(specFuzzy)) {
                         WFO.match1 <- WFO.data[WFO.data$scientificName==specFuzzy[j],]
                         if (j==1) {
                             WFO.match <- WFO.match1

--- a/R/WFO.match.R
+++ b/R/WFO.match.R
@@ -20,10 +20,13 @@ WFO.match <- function(
     verbose=TRUE, counter=1000
 )
 {
-    if (class(spec.data) %in% c("data.frame") == FALSE) {spec.data <- data.frame(spec.name = spec.data)}
-    if (is.factor(spec.data) == TRUE) {spec.data <- data.frame(spec.name = spec.data)}
-
+    # Check that data.table is installed
     if (! requireNamespace("data.table")) {stop("Please install the data.table package")}
+
+    # Check whether spec.data is a data.table or a data.frame
+    if ((!data.table::is.data.table(spec.data)) & (!is.data.frame(spec.data))) {spec.data <- data.frame(spec.name = spec.data)}
+    
+    if (is.factor(spec.data) == TRUE) {spec.data <- data.frame(spec.name = spec.data)}
 
     if (is.null(WFO.data) == TRUE) {
         message(paste("Reading WFO data"))

--- a/R/WFO.match.R
+++ b/R/WFO.match.R
@@ -23,8 +23,8 @@ WFO.match <- function(
     # Check that data.table is installed
     if (! requireNamespace("data.table")) {stop("Please install the data.table package")}
 
-    # Check whether spec.data is a data.table or a data.frame
-    if ((!data.table::is.data.table(spec.data)) & (!is.data.frame(spec.data))) {spec.data <- data.frame(spec.name = spec.data)}
+    # Convert spec.data to a data.frame if it is a data.table of if it not a data.frame
+    if ((data.table::is.data.table(spec.data)) | (!is.data.frame(spec.data))) {spec.data <- data.frame(spec.name = spec.data)}
     
     if (is.factor(spec.data) == TRUE) {spec.data <- data.frame(spec.name = spec.data)}
 

--- a/R/WFO.prepare.R
+++ b/R/WFO.prepare.R
@@ -12,7 +12,12 @@ WFO.prepare <- function(
     verbose=TRUE, counter=1000
 )
 {
-    if (class(spec.data) %in% c("data.frame") == FALSE) {spec.data <- data.frame(spec.full = spec.data)}
+    # Check that data.table is installed
+    if (! requireNamespace("data.table")) {stop("Please install the data.table package")}
+
+    # Check whether spec.data is a data.table or a data.frame
+    if ((!data.table::is.data.table(spec.data)) & (!is.data.frame(spec.data))) {spec.data <- data.frame(spec.full = spec.data)}
+    
     if (is.factor(spec.data) == TRUE) {spec.data <- data.frame(spec.full = spec.data)}
 
     WFO.names <- c("spec.name", "Authorship")

--- a/R/WFO.prepare.R
+++ b/R/WFO.prepare.R
@@ -15,8 +15,8 @@ WFO.prepare <- function(
     # Check that data.table is installed
     if (! requireNamespace("data.table")) {stop("Please install the data.table package")}
 
-    # Check whether spec.data is a data.table or a data.frame
-    if ((!data.table::is.data.table(spec.data)) & (!is.data.frame(spec.data))) {spec.data <- data.frame(spec.full = spec.data)}
+    # Convert spec.data to a data.frame if it is a data.table of if it not a data.frame
+    if ((data.table::is.data.table(spec.data)) | (!is.data.frame(spec.data))) {spec.data <- data.frame(spec.full = spec.data)}
     
     if (is.factor(spec.data) == TRUE) {spec.data <- data.frame(spec.full = spec.data)}
 

--- a/R/WFO.url.R
+++ b/R/WFO.url.R
@@ -5,8 +5,8 @@ WFO.url <- function(
 	# Check that data.table is installed
     if (! requireNamespace("data.table")) {stop("Please install the data.table package")}
 
-    # Check whether spec.data is a data.table or a data.frame
-    if ((!data.table::is.data.table(WFO.result)) & (!is.data.frame(WFO.result))) {WFO.result <- data.frame(taxonID = WFO.result)}
+    # Convert WFO.result to a data.frame if it is a data.table of if it not a data.frame
+    if ((data.table::is.data.table(WFO.result)) & (!is.data.frame(WFO.result))) {WFO.result <- data.frame(taxonID = WFO.result)}
     if (is.factor(WFO.result) == TRUE) {WFO.result <- data.frame(taxonID = WFO.result)}
 
     result <- as.character(NA, length=nrow(WFO.result))

--- a/R/WFO.url.R
+++ b/R/WFO.url.R
@@ -2,7 +2,11 @@ WFO.url <- function(
     WFO.result=NULL, browse=FALSE, browse.rows=c(1:1), ...
 )
 {
-    if (class(WFO.result) %in% c("data.frame") == FALSE) {WFO.result <- data.frame(taxonID = WFO.result)}
+	# Check that data.table is installed
+    if (! requireNamespace("data.table")) {stop("Please install the data.table package")}
+
+    # Check whether spec.data is a data.table or a data.frame
+    if ((!data.table::is.data.table(WFO.result)) & (!is.data.frame(WFO.result))) {WFO.result <- data.frame(taxonID = WFO.result)}
     if (is.factor(WFO.result) == TRUE) {WFO.result <- data.frame(taxonID = WFO.result)}
 
     result <- as.character(NA, length=nrow(WFO.result))


### PR DESCRIPTION
As written in the bug #1 an error occurs with R version > 4.2.0 when using a data table which is also a data frame. Then the condition is of length > 1 whenever testing the class of object XYZ: `class(XYZ) %in% c("data.frame") == FALSE`.

I replaced this by `!data.table::is.data.table(XYZ) & !is.data.frame(XYZ)`